### PR TITLE
regression_1000: Fix 1020 test when Pseudo TA is disabled

### DIFF
--- a/src/regression_1000.c
+++ b/src/regression_1000.c
@@ -1392,10 +1392,13 @@ ZTEST(regression_1000, test_1020)
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL, &ret_orig);
 	if (res == TEEC_ERROR_ITEM_NOT_FOUND) {
 		printk(" - 1020 -   skip test, pseudo TA not found\n");
+		return;
+	}
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(&c, res)) {
 		ADBG_Assert(&c);
 		return;
 	}
-	ADBG_EXPECT_TEEC_SUCCESS(&c, res);
 
 	res = TEEC_InvokeCommand(&session, PTA_INVOKE_TESTS_CMD_LOCKDEP,
 				 NULL, &ret_orig);


### PR DESCRIPTION
It was found that OP-TEE can return BAD_PARAMETERS error instead of NOT_FOUND when pseudo TA is disabled in OP-TEE. In this case EXPECT_TEEC_SUCCESS result should be checked and error returned if we unable to open session. Not checking this result leads to an Exception of invoking command on bad session_id.